### PR TITLE
Replace getAllIds() with getItems() to retain all search criteria

### DIFF
--- a/app/code/Magento/Catalog/Model/CategoryList.php
+++ b/app/code/Magento/Catalog/Model/CategoryList.php
@@ -77,10 +77,7 @@ class CategoryList implements CategoryListInterface
 
         $this->collectionProcessor->process($searchCriteria, $collection);
 
-        $items = [];
-        foreach ($collection->getAllIds() as $id) {
-            $items[] = $this->categoryRepository->get($id);
-        }
+        $items = $collection->getItems();
 
         /** @var CategorySearchResultsInterface $searchResult */
         $searchResult = $this->categorySearchResultsFactory->create();


### PR DESCRIPTION
### Description (*)
The `getAllIds()` function from the `Collection` filters out all order, column and page size settings which has been set in the SearchCriteria argument (see `_getAllIdsSelect()` function in **_vendor/magento/module-eav/Model/Entity/Collection/AbstractCollection.php:954_**), which makes this `getList()` function useless in certain situations to retrieve all categories. This `getList()` function makes it impossible to order by attributes, set pagesizes and add certain column (for the SQL query) conditions via the `SearchCriteria` object. It also seems unnecessary and slow to run a query to retrieve all IDs and then run new queries to retrieve all data based on that ID.


### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
N/A

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
